### PR TITLE
fix: redirect url 수정

### DIFF
--- a/zerogravity/src/main/java/com/zerogravity/myapp/controller/OAuth2Controller.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/controller/OAuth2Controller.java
@@ -3,6 +3,7 @@ package com.zerogravity.myapp.controller;
 import java.net.URI;
 import java.util.Map;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -48,7 +49,7 @@ public class OAuth2Controller {
 	}
 
 	@GetMapping("/kakao")
-	public ResponseEntity<?> getAccessToken(@RequestParam("code") String code, HttpServletResponse response) {
+	public ResponseEntity<?> getAccessToken(@RequestParam("code") String code, HttpServletRequest request, HttpServletResponse response) {
 
 		// 1. 토큰 받기
 		HttpHeaders httpHeaders = new HttpHeaders();
@@ -125,8 +126,17 @@ public class OAuth2Controller {
 
 		response.addCookie(jwtCookie);
 
-		// 사용자 정보와 JWT 반환
-		return ResponseEntity.status(HttpStatus.FOUND).location(URI.create("/")).build();
+		String redirectBase;
 
+		if (request.getServerName().contains("localhost")) {
+			redirectBase = "http://localhost:5173";
+		} else if (request.getServerName().contains("devapi.zerogv.com")) {
+			redirectBase = "https://dev.zerogv.com";
+		} else {
+			redirectBase = "https://zerogv.com";
+		}
+
+		// 사용자 정보와 JWT 반환
+		return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(redirectBase)).build();
 	}
 }


### PR DESCRIPTION
## 📌 변경 내용

- 백엔드에서 요청 호스트(`request.getServerName()`) 기반으로 리다이렉트 URI 분기 처리
  - `localhost` 요청 시 → `http://localhost:5173`
  - `devapi.zerogv.com` 요청 시 → `https://dev.zerogv.com`
  - 그 외 기본값은 → `https://zerogv.com`
- 카카오 OAuth 로그인 완료 후 redirect URI를 환경에 맞게 동적으로 반환

## 🔧 추가 작업

- 추후 Vercel 및 프론트엔드 `dev.zerogv.com` 서브도메인 연결 필요
- 카카오 개발자 콘솔에 `dev.apizerogv.com/login/oauth2/code/kakao` 등록 필요

## ✅ 테스트

- [x] 로컬 `localhost:8080` → `http://localhost:5173`로 정상 리다이렉트
- [ ] dev 서버 배포 후 `apidev.zerogv.com` 테스트 예정
