### PR TITLE
✨ feat: Return 409 USER_DEACTIVATED for soft-deleted user login

### DIFF
--- a/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.zerogravity.myapp.auth.dto.RefreshRequest;
 import com.zerogravity.myapp.auth.dto.RefreshResponse;
 import com.zerogravity.myapp.auth.service.RefreshTokenService;
 import com.zerogravity.myapp.common.dto.ApiResponse;
+import com.zerogravity.myapp.common.dto.ErrorResponse;
 import com.zerogravity.myapp.user.dto.User;
 import com.zerogravity.myapp.user.service.UserService;
 import com.zerogravity.myapp.common.security.JWTUtil;
@@ -86,6 +87,16 @@ public class AuthController {
 
 			// 2. Create a new user if it doesn't exist
 			if (user == null) {
+				// Check if a soft-deleted user exists (deactivated account)
+				if (userService.existsDeletedUser(oauthUser.getProviderId(), oauthUser.getProvider())) {
+					ErrorResponse errorResponse = new ErrorResponse(
+						"USER_DEACTIVATED",
+						"This account has been deactivated. Please contact support to restore.",
+						Instant.now().toString()
+					);
+					return ResponseEntity.status(HttpStatus.CONFLICT).body(new ApiResponse<>(false, errorResponse, Instant.now().toString()));
+				}
+
 				// Generate Snowflake ID (unique, non-sequential, sortable)
 				long newUserId = snowflakeIdService.generateId();
 				oauthUser.setUserId(newUserId);

--- a/zerogravity/src/main/java/com/zerogravity/myapp/user/dao/UserDao.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/user/dao/UserDao.java
@@ -28,6 +28,14 @@ public interface UserDao {
 	User selectUserByProviderIdAndProvider(@Param("providerId") String providerId, @Param("provider") String provider);
 
 	/**
+	 * Select soft-deleted user by OAuth provider ID and provider name
+	 * @param providerId OAuth provider ID
+	 * @param provider Provider name (e.g., "kakao", "google")
+	 * @return Soft-deleted User object or null if not found
+	 */
+	User selectDeletedUserByProviderIdAndProvider(@Param("providerId") String providerId, @Param("provider") String provider);
+
+	/**
 	 * Insert a new user
 	 * @param user User object to insert
 	 * @return Number of rows affected

--- a/zerogravity/src/main/java/com/zerogravity/myapp/user/service/UserService.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/user/service/UserService.java
@@ -25,6 +25,14 @@ public interface UserService {
 	public abstract User getUserByProviderIdAndProvider(String providerId, String provider);
 
 	/**
+	 * Check if a soft-deleted user exists by provider
+	 * @param providerId OAuth provider ID
+	 * @param provider Provider name
+	 * @return true if soft-deleted user exists
+	 */
+	public abstract boolean existsDeletedUser(String providerId, String provider);
+
+	/**
 	 * Create a new user
 	 * @param user User object to create
 	 * @return true if creation successful, false otherwise

--- a/zerogravity/src/main/java/com/zerogravity/myapp/user/service/UserServiceImpl.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/user/service/UserServiceImpl.java
@@ -33,6 +33,12 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
+	public boolean existsDeletedUser(String providerId, String provider) {
+		return userDao.selectDeletedUserByProviderIdAndProvider(providerId, provider) != null;
+	}
+
+	@Override
 	@Transactional
 	public boolean createUser(User user) {
 		int userResult = userDao.insertUser(user);

--- a/zerogravity/src/main/resources/mappers/user/userMapper.xml
+++ b/zerogravity/src/main/resources/mappers/user/userMapper.xml
@@ -28,6 +28,18 @@
 		  AND is_deleted = FALSE
 	</select>
 
+	<!-- Select soft-deleted user by provider ID and provider -->
+	<select id="selectDeletedUserByProviderIdAndProvider" resultType="User">
+		SELECT user_id, provider_id, provider, email, name, image, is_deleted, deleted_at,
+		       terms_agreed, terms_agreed_at, privacy_agreed, privacy_agreed_at,
+		       sensitive_data_consent, sensitive_data_consent_at, ai_analysis_consent, ai_analysis_consent_at,
+		       consent_version, created_time, updated_time
+		FROM user
+		WHERE provider_id = #{providerId}
+		  AND provider = #{provider}
+		  AND is_deleted = TRUE
+	</select>
+
 	<!-- Insert new user -->
 	<insert id="insertUser" parameterType="User">
 		INSERT INTO user (user_id, provider_id, provider, email, name, image)


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

Prevents UNIQUE constraint violation when a soft-deleted user attempts to login again. Returns a specific 409 error code so the frontend can show an appropriate message.

### ✨ **Key Features**

#### 1. **Soft-Deleted User Detection**

- **New Query**: `selectDeletedUserByProviderIdAndProvider` in `userMapper.xml` to find users with `is_deleted = TRUE`
- **Service Method**: `existsDeletedUser()` in `UserService/Impl`
- **Controller Logic**: `AuthController` checks for soft-deleted user before INSERT, returns `409 USER_DEACTIVATED` instead of crashing with UNIQUE constraint violation

### 🔧 **Technical Details**

- **Error Response**: `{ error: "USER_DEACTIVATED", message: "This account has been deactivated..." }`
- **HTTP Status**: 409 Conflict
- **Breaking Changes**: None — new error code only, existing flows unaffected

### 📋 **Frontend Requirements**

- Frontend should handle 409 `USER_DEACTIVATED` response and show "탈퇴한 계정" modal
- See companion PR in `zerogravity-react`

### 🧪 **Testing**

- [ ] Manual testing: soft-deleted user login returns 409
- [ ] Build successful

### 📋 **Checklist**

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Domain-based architecture maintained