### PR TITLE
🐛 fix: Use GlobalExceptionHandler for deactivated user error

### DIFF
--- a/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ import com.zerogravity.myapp.auth.dto.RefreshRequest;
 import com.zerogravity.myapp.auth.dto.RefreshResponse;
 import com.zerogravity.myapp.auth.service.RefreshTokenService;
 import com.zerogravity.myapp.common.dto.ApiResponse;
-import com.zerogravity.myapp.common.dto.ErrorResponse;
+import com.zerogravity.myapp.auth.exception.UserDeactivatedException;
 import com.zerogravity.myapp.user.dto.User;
 import com.zerogravity.myapp.user.service.UserService;
 import com.zerogravity.myapp.common.security.JWTUtil;
@@ -89,12 +89,7 @@ public class AuthController {
 			if (user == null) {
 				// Check if a soft-deleted user exists (deactivated account)
 				if (userService.existsDeletedUser(oauthUser.getProviderId(), oauthUser.getProvider())) {
-					ErrorResponse errorResponse = new ErrorResponse(
-						"USER_DEACTIVATED",
-						"This account has been deactivated. Please contact support to restore.",
-						Instant.now().toString()
-					);
-					return ResponseEntity.status(HttpStatus.CONFLICT).body(new ApiResponse<>(false, errorResponse, Instant.now().toString()));
+					throw new UserDeactivatedException("This account has been deactivated. Please contact support to restore.");
 				}
 
 				// Generate Snowflake ID (unique, non-sequential, sortable)

--- a/zerogravity/src/main/java/com/zerogravity/myapp/auth/exception/UserDeactivatedException.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/auth/exception/UserDeactivatedException.java
@@ -1,0 +1,12 @@
+package com.zerogravity.myapp.auth.exception;
+
+/**
+ * Exception thrown when a deactivated (soft-deleted) user attempts to login
+ * Returns HTTP 409 Conflict response
+ */
+public class UserDeactivatedException extends RuntimeException {
+
+    public UserDeactivatedException(String message) {
+        super(message);
+    }
+}

--- a/zerogravity/src/main/java/com/zerogravity/myapp/common/exception/GlobalExceptionHandler.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import com.zerogravity.myapp.emotion.exception.MomentNotEditableException;
 import com.zerogravity.myapp.ai.exception.GeminiApiException;
 import com.zerogravity.myapp.ai.exception.AIAnalysisCacheException;
 import com.zerogravity.myapp.auth.exception.UnauthorizedException;
+import com.zerogravity.myapp.auth.exception.UserDeactivatedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -162,6 +163,22 @@ public class GlobalExceptionHandler {
 		);
 
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+	}
+
+	@ExceptionHandler(UserDeactivatedException.class)
+	public ResponseEntity<ErrorResponse> handleUserDeactivatedException(
+		UserDeactivatedException ex, WebRequest request) {
+
+		String timezone = request.getHeader("X-Timezone");
+		ZoneId zoneId = timezone != null ? ZoneId.of(timezone) : ZoneId.of("UTC");
+
+		ErrorResponse error = new ErrorResponse(
+			"USER_DEACTIVATED",
+			ex.getMessage(),
+			TimezoneUtil.formatToUserTimezone(Instant.now(), zoneId)
+		);
+
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
 	}
 
 	@ExceptionHandler(UnauthorizedException.class)


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

Fixes compile error from PR #83. Uses project's existing exception handling pattern (throw → GlobalExceptionHandler) instead of returning ErrorResponse directly from controller.

### ✨ **Key Features**

#### 1. **Proper Exception Pattern**

- **UserDeactivatedException**: New exception class in `auth/exception/`
- **AuthController**: Throws exception instead of returning ErrorResponse directly (fixes generic type mismatch)
- **GlobalExceptionHandler**: Catches exception and returns `409 Conflict` with `USER_DEACTIVATED` error code

### 🔧 **Technical Details**

- **Root Cause**: `ResponseEntity<ApiResponse<AuthResponse>>` return type cannot hold `ApiResponse<ErrorResponse>`
- **Fix**: Follow existing pattern — throw exception, let GlobalExceptionHandler handle the response
- **Breaking Changes**: None — same 409 status + error code, different internal flow

### 🧪 **Testing**

- [x] Build successful (`mvn compile`)

### 📋 **Checklist**

- [x] Code follows project style guidelines
- [x] Self-review completed