### PR TITLE
🐛 fix: Rethrow UserDeactivatedException to reach GlobalExceptionHandler

### DIFF
--- a/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/auth/controller/AuthController.java
@@ -145,6 +145,8 @@ public class AuthController {
 			ApiResponse<AuthResponse> apiResponse = new ApiResponse<>(authResponse, Instant.now().toString());
 			return ResponseEntity.ok(apiResponse);
 
+		} catch (UserDeactivatedException e) {
+			throw e; // Let GlobalExceptionHandler handle 409 response
 		} catch (Exception e) {
 			System.err.println("[AuthController] Error during OAuth verification: " + e.getMessage());
 			e.printStackTrace();


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

`catch(Exception)` in `AuthController` was swallowing `UserDeactivatedException` and returning 500 instead of letting GlobalExceptionHandler return 409.

### ✨ **Key Features**

- **Fix**: Add `catch(UserDeactivatedException) { throw e; }` before generic catch block
- **Result**: Deactivated user login now returns 409 + `USER_DEACTIVATED`

### 🧪 **Testing**

- [x] Build successful

### 📋 **Checklist**

- [x] Self-review completed