### PR TITLE
🔧 ci: Add workflow_dispatch trigger for manual deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

Add `workflow_dispatch` event trigger to the backend deploy workflow so that production redeploys can be triggered manually from the GitHub Actions UI (or `gh workflow run` CLI), without needing a dummy commit.

This is motivated by an OCI Always Free boot volume reset event where the running container state was wiped but no application code had changed, so there was no natural commit to re-trigger the deploy workflow. The previous workflow only had `on: push` triggers and the latest main run was outside GitHub's 1-month rerun window, leaving no clean way to redeploy.

### ✨ **Key Changes**

#### 1. **Manual Workflow Trigger**

- **`workflow_dispatch:` added to `.github/workflows/deploy.yml`**: Enables manual runs from the GitHub UI / CLI in addition to existing push triggers.
- **No behavior change for existing pushes**: All current push-based behavior on `develop` and `main` is preserved.

### 🔧 **Technical Details**

- **Resources Added**: `workflow_dispatch:` event in deploy workflow
- **Resources Modified**: None (no Java/Spring code changes)
- **Resources Removed**: None
- **Breaking Changes**: None

### 🧪 **Testing**

- [x] Dev redeploy via this commit succeeded
- [x] `https://api-dev.zerogv.com/actuator/health` returns `{"status":"UP"}`
- [x] Backend + MySQL containers healthy in dev

### 📋 **Checklist**

- [x] No application code changes
- [x] Self-review completed
- [x] Existing push trigger behavior preserved
- [x] No hardcoded secrets