### PR TITLE
🐛 fix: Remove double 1.5x daily weighting from match score

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Base URL: `https://api.zerogv.com`
   - Year: 365 → 12 records (1 per month)
   - Month: ~30 → 4 records (1 per week)
 - **Smart Matching Algorithm**: 60% emotion level + 40% reason matching
-- **Daily 1.5x Weighting**: Daily records weighted higher (more representative than moment)
+- **Daily-weighted average**: daily records count 1.5x toward the bucket average
 - **Tie-breaking**: score → diary length → reason count → recency
 - **Prompt Design**: JSON-only response, emotion level mapping (0-6), predefined reasons
 
@@ -264,10 +264,8 @@ Base URL: `https://api.zerogv.com`
 ```java
 // Select best matching record per bucket using weighted scoring
 private double calculateMatchScore(EmotionRecord record, Double targetLevel, String topReason) {
-    // Daily records weighted 1.5x (more representative)
-    double recordLevel = record.getEmotionId() *
-        (record.getEmotionRecordType() == EmotionRecord.Type.DAILY ? 1.5 : 1.0);
-    double levelScore = 1.0 - (Math.abs(recordLevel - targetLevel) / 9.0);
+    // Level score: distance from the bucket average (levels are 0-6)
+    double levelScore = 1.0 - (Math.abs(record.getEmotionId() - targetLevel) / 6.0);
 
     // Reason matching
     double reasonScore = record.getEmotionReasons().contains(topReason) ? 1.0 : 0.0;

--- a/zerogravity/src/main/java/com/zerogravity/myapp/ai/service/AIAnalysisServiceImpl.java
+++ b/zerogravity/src/main/java/com/zerogravity/myapp/ai/service/AIAnalysisServiceImpl.java
@@ -463,7 +463,7 @@ public class AIAnalysisServiceImpl implements AIAnalysisService {
 
 	/**
 	 * Find the best matching record based on level and reason matching
-	 * Applies Daily record 1.5x weighting to level comparison
+	 * Ties fall through to diary length, reason count, then recency
 	 */
 	private EmotionRecord findBestMatchingRecord(
 			List<EmotionRecord> records,
@@ -489,14 +489,12 @@ public class AIAnalysisServiceImpl implements AIAnalysisService {
 
 	/**
 	 * Calculate match score for a record
-	 * Applies Daily 1.5x weighting to level comparison
+	 * The bucket average already weights daily records 1.5x, so no type bonus is applied here
 	 */
 	private double calculateMatchScore(EmotionRecord record, Double targetLevel, String topReason) {
-		// Level score with Daily weighting
-		double recordLevel = record.getEmotionId() *
-				(record.getEmotionRecordType() == EmotionRecord.Type.DAILY ? 1.5 : 1.0);
-		double levelDiff = Math.abs(recordLevel - targetLevel);
-		double levelScore = 1.0 - (levelDiff / 9.0); // Max diff = 6 * 1.5 = 9
+		// Level score: distance from the bucket average
+		double levelDiff = Math.abs(record.getEmotionId() - targetLevel);
+		double levelScore = 1.0 - (levelDiff / 6.0); // Max diff = 6 (levels are 0-6)
 		levelScore = Math.max(0.0, Math.min(1.0, levelScore)); // Clamp to [0, 1]
 
 		// Reason score


### PR DESCRIPTION
## 📝 **PR Description**

### 🎯 **Overview**

Representative-record selection for AI analysis applied the Daily `1.5x` weighting twice, which skewed which record was chosen to represent each bucket (month for year period, week for month period). The weighting already lives in the SQL that computes the bucket average, so applying it again in `calculateMatchScore` compared two different scales against each other. This PR removes the duplicate weighting and fixes the score normalization.

### ✨ **Key Features**

#### 1. **Match Score Correction**

- **Removed duplicate weighting**: `calculateMatchScore` no longer multiplies a record's own `emotionId` by `1.5` for Daily records. The bucket average (`targetLevel`) already applies the Daily `1.5x` weight through `emotionRecordMapper.xml:104-105` (`SUM(emotion_level * 1.5 for daily) / SUM(weights)`), so the average stays on the raw 0-6 scale.
- **Fixed the scale mismatch**: previously a Daily record at level 4 was scored as `6.0` and compared against an average on the 0-6 scale, inflating its distance and pushing genuinely representative Daily records out of selection.
- **Corrected normalization**: the divisor changed from `9.0` (which assumed a max diff of `6 * 1.5`) to `6.0`, the real maximum distance between two levels on a 0-6 scale. This restores the intended spread of `levelScore` instead of compressing it toward `1.0`.
- **User Impact**: the record surfaced to the AI for each month/week bucket is now the one actually closest to that bucket's emotional average, making the generated analysis more faithful to the user's data.

#### 2. **Documentation & Comments**

- **README**: the "Smart Matching Algorithm" section now describes the weighting where it actually happens (daily-weighted bucket average) and the embedded code sample matches the shipped implementation.
- **Javadoc**: `findBestMatchingRecord` documents its real tie-breaking chain (score → diary length → reason count → recency) rather than the removed weighting, and `calculateMatchScore` explains why no type bonus is applied.

### 🔧 **Technical Details**

- **Dependencies**: none added
- **Breaking Changes**: none — no API signature, request, or response shape changes
- **Behavioral note**: this is an internal scoring change. For the same input data the AI analysis may now pick a different representative record per bucket, which is the intended fix
- **Scoring weights unchanged**: still 60% level match + 40% reason match

### 🧪 **Testing**

- [x] Build successful (`./mvnw compile` → BUILD SUCCESS)
- [ ] Unit tests added/updated — no test exists for `calculateMatchScore`; the method is private and currently uncovered
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Swagger UI verified — N/A, no API surface change

### 📋 **Checklist**

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (README + Javadoc)
- [x] Domain-based architecture maintained
- [x] No new warnings introduced

### 📋 **Frontend Requirements**

None. No API contract change.
